### PR TITLE
Inexact matching on filters, avoid read.csv warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: inspiRe
 Title: Get Storytelling with Data Inspiration
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Authors@R: 
     person(given = "Sara",
            family = "Stoudt",
@@ -13,5 +13,3 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
-Imports:
-  pkgcond

--- a/R/inspire_me.R
+++ b/R/inspire_me.R
@@ -9,7 +9,12 @@
 #' @return A URL
 #' @export
 inspire_me <- function(author = "", affiliation = "", topic = "", type = "") {
-  data <- pkgcond::suppress_warnings(utils::read.csv(system.file("extdata", "links.csv", package = "inspiRe"), stringsAsFactors = F), "incomplete final line")
+  data <- read.table(
+    text = readLines(system.file("extdata", "links.csv", package = "inspiRe"), warn = FALSE),
+    header = TRUE,
+    sep = ",",
+    stringsAsFactors = FALSE
+  )
 
   if (author != "") {
     data <- subset(data, grepl(author, author_name, ignore.case = TRUE))

--- a/R/inspire_me.R
+++ b/R/inspire_me.R
@@ -12,19 +12,19 @@ inspire_me <- function(author = "", affiliation = "", topic = "", type = "") {
   data <- pkgcond::suppress_warnings(utils::read.csv(system.file("extdata", "links.csv", package = "inspiRe"), stringsAsFactors = F), "incomplete final line")
 
   if (author != "") {
-    data <- subset(data, author_name == author)
+    data <- subset(data, grepl(author, author_name, ignore.case = TRUE))
   }
 
   if (affiliation != "") {
-    data <- subset(data, author_affiliation == affiliation)
+    data <- subset(data, grepl(affiliation, author_affiliation, ignore.case = TRUE))
   }
 
   if (topic != "") {
-    data <- subset(data, content_topic == topic)
+    data <- subset(data, grepl(topic, content_topic, ignore.case = TRUE))
   }
 
   if (type != "") {
-    data <- subset(data, content_type == type)
+    data <- subset(data, grepl(type, content_type, ignore.case = TRUE))
   }
 
   num_inspire <- nrow(data)

--- a/R/inspire_me.R
+++ b/R/inspire_me.R
@@ -9,7 +9,7 @@
 #' @return A URL
 #' @export
 inspire_me <- function(author = "", affiliation = "", topic = "", type = "") {
-  data <- read.table(
+  data <- utils::read.table(
     text = readLines(system.file("extdata", "links.csv", package = "inspiRe"), warn = FALSE),
     header = TRUE,
     sep = ",",


### PR DESCRIPTION
Letting the filtering be inexact (only needs to contain it, and case is ignored!). Also using read.table and readLines to avoid that end of file line warning, so the package is dependency free! 🎉  (ps thanks stack overflow I didn't figure this out myself: https://stackoverflow.com/a/50124708)

closes #2, closes #3